### PR TITLE
docs(spec): describe CI behavior

### DIFF
--- a/specs/duvet-specification.md
+++ b/specs/duvet-specification.md
@@ -3,6 +3,26 @@
 
 # Duvet specification
 
+## Version
+
+0.2.0
+
+### Changelog
+
+- 0.2.0
+
+  - Initial record
+
+- 0.1.0
+
+  - "Specless" Rust Implementation
+
+## Overview
+
+This document introduces and describes Duvet.
+
+Any implementation of Duvet MUST follow this specification.
+
 ## Introduction
 
 Duvet is an application to build confidence that your software is correct.
@@ -22,23 +42,33 @@ Are there annotations in your source that do not exist in your specification?
 Does every cited requirement from your specification have a test?
 This report can either be a pass/fail for CI or an interactive report for development and code review.
 
+### Conventions used in this document
+
+The keywords
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in [RFC2119](https://tools.ietf.org/html/rfc2119).
+
+# Structures
+
+This following sections describe the common Duvet structures and their behavior.
+
 ## Specification
 
 A specification is a document, like this, that defines correct behavior.
 This behavior is defined in regular human language.
 
-### Section
+## Section
 
 The top level header for requirements is the name of a section.
 The name of the sections MUST NOT be nested.
-A requirements section MUST be the top level containing header.
+A requirements' section MUST be the top level containing header.
 A header MUST NOT itself be a requirement.
 
 A section MUST be indexable by combining different levels of naming.
 This means that Duvet needs to be able to locate it uniquely within a specification.
 A good example of a section is a header in an HTML or Markdown document.
 
-### Requirement
+## Requirement
 
 Any complete sentence containing at least one RFC 2119 keyword MUST be treated as a requirement.
 A requirement MAY contain multiple RFC 2119 keywords.
@@ -93,12 +123,10 @@ For a given a specification Duvet MUST use one way to identify requirements.
 
 Duvet MUST be able to parse specifications formatted as:
 
-- markdown
-- ietf
+- Markdown
+- IETF style RFCs as text files.
 
-#### Toml
-
-Duvet SHOULD be able to parse requirements formatted as Toml files.
+#### Requirements to TOML
 
 Duvet SHOULD be able to record parsed requirements into Toml Files.
 
@@ -173,7 +201,7 @@ Each type is listed here with its intended usage.
   For example take a requirement that a function take a specific set of arguments.
   In a static strongly typed language the arguments of a function can not change.
   So an implication could be a good choice to express that the implementation satisfies this requirement.
-- Todo: The suggested location for the implementation.
+- TODO: The suggested location for the implementation.
 
 ### Content
 
@@ -267,6 +295,10 @@ The Requirement Statuses MUST be:
 - Missing Implementation - The requirement MUST only have the label `Attested`
 - Not started - The requirement MUST NOT have any labels
 - Missing Reason - The requirement MUST have the label `Unexcused`
+- Duvet Error - The requirements matching labels MUST be invalid.
+
+[//]: # "TODO: Should `Duvet Error` trigger a warning/exception?"
+[//]: # "TODO: Should `Duvet Error` cause a Fail?"
 
 ### Pass/Fail
 
@@ -326,3 +358,118 @@ The table MUST have a column for:
 - Requirement key word - key word defined in rfc2119
 - Status
 - Text - The requirement text
+
+# Behaviors
+
+Duvet MUST support a [CI Behavior](#ci-behavior).
+
+Duvet SHOULD support a [Requirement to TOML Behavior](#record-requirements-as-toml-behavior).
+
+[//]: # "TODO: Define all of behaviors input and output in one place"
+[//]: # "TODO: Describe how Duvet should handle exceptions"
+
+## CI Behavior
+
+The following sections describe
+how Duvet parses specifications and implementations
+to generate a report and a pass/fail status appropriate
+for continuous integration (CI) usage.
+
+Implementations of Duvet MUST implement this behavior.
+
+This MUST be the default execution of Duvet.
+
+This behavior MUST accept a configuration file.
+
+### Parse Specifications
+
+Duvet MUST accept one or more groups of file patterns that describe the paths to the specifications files.
+
+These file pattern groups MUST specify which [specification format](#formats) they are in.
+
+For each file pattern group,
+for each file pattern in the group,
+Duvet MUST attempt to parse as a [specification](#specification) any files
+discovered on this file pattern
+as if they were in the file pattern groups' [specification format](#formats).
+
+Failure to parse a file MUST NOT halt Duvet.
+
+Failure to parse a file SHOULD yield a warning.
+
+#### Specifications as TOML
+
+In addition to parsing Markdown and RFC (`.txt`) files as specifications,
+Duvet SHOULD accept one or more file patterns that describe the paths to `.toml` files.
+
+Duvet SHOULD interpret each directory containing one or more TOML files as a [specification](#specification).
+
+See [Sections as TOML](#sections-as-toml).
+
+### Extract Sections
+
+Duvet MUST extract [sections](#section) from [specifications](#specification).
+
+#### Sections as TOML
+
+If Duvet has interpreted TOML directories as [specifications](#specification),
+Duvet SHOULD interpret each TOML file in a directory
+as a [section](#section) of that directories' specification.
+
+See [Requirements from TOML](#requirements-from-toml).
+
+### Extract Requirements.
+
+Duvet MUST extract [Requirements](#requirement) from [Sections](#section).
+
+#### Requirements from TOML
+
+If Duvet has interpreted TOML files as a [section](#section),
+for every [array of tables](https://toml.io/en/v1.0.0#array-of-tables) in the TOML file,
+Duvet SHOULD extract a [requirement](#requirement).
+
+### Parse Implementation
+
+Duvet MUST accept one or more file pattern groups that describe the paths to the implementation files.
+
+Each file pattern group MAY be associated with an annotation identifier tuple,
+which MUST be used when parsing files from the file pattern group.
+
+Otherwise, the default annotation identifiers MUST be used for that file pattern group.
+
+For each file pattern group,
+for each file pattern in the group,
+for every file found via a file pattern,
+Duvet MUST extract [annotations](#annotation) form that file
+with the group's annotation identifiers.
+
+Failure to parse a file MUST NOT halt Duvet.
+
+Failure to parse a file SHOULD yield a warning.
+
+Duvet MUST attempt to match these [annotations](#annotation) to [requirements](#requirement)
+as described in [Matching](#matching).
+
+Even if a match is not found,
+Duvet MUST record every [annotation](#annotation).
+
+### Generate Report
+
+Duvet MUST analyze every [requirement](#requirement) extracted,
+generating and validating matching labels as described in [Matching Labels](#matching-labels).
+
+Then, Duvet MUST determine every [requirement's](#requirement) [Status](#status).
+
+Duvet MUST generate an HTML report as described in [report](#report).
+
+### Pass or Fail
+
+Duvet MUST Pass or Fail as described in [Pass/Fail](#Pass/Fail).
+
+## Record Requirements as TOML Behavior
+
+Duvet SHOULD support requirement to Toml extraction as a separate utility that MAY be invoked outside normal execution.
+
+See Requirements from TOML, Sections as TOML, and Specifications as TOML.
+
+[//]: # "TODO: Flesh this out"


### PR DESCRIPTION
*Issue #, if available:* describe Duvet's behaviors. 

*Description of changes:*
1. "Version-ed" the spec.
2. Added RFC Keyword blurb.
3. Added `Duvet Error` to Requirement Status to address @lavaleri 's point (more below).
4. Described Duvet's CI behavior (we never said: Duvet MUST extract Requirements/Annotations/etc.).
5. Started Describing Requirement to TOML behavior
6. left some TODOs for us.

*lavaleri's point*:
Duvet's Requirement's Status were not comprehensive
of all possible Matching Label statuses.
I added `Duvet Error` to catch illegal states (i.e.: `Implemented` and `Execused`). 

*Testing*: CI:
```
❯ ./ci/prettify.sh check
Checking formatting...
All matched files use Prettier code style!
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
